### PR TITLE
Fixed add_listener() crashing due to scope 

### DIFF
--- a/src/api.lua
+++ b/src/api.lua
@@ -5,6 +5,7 @@ do -- VERSION 2.9
   MODULES = {}
   foreach(
     ls("mods/" .. MODNAME .. "/modules/"), function(module_name)
+      if module_name:sub(-4) ~= ".lua" then
         return
       end
       local module = table_from_file("mods/" .. MODNAME .. "/modules/" .. module_name:sub(1, -5))

--- a/src/api.lua
+++ b/src/api.lua
@@ -5,7 +5,6 @@ do -- VERSION 2.9
   MODULES = {}
   foreach(
     ls("mods/" .. MODNAME .. "/modules/"), function(module_name)
-      if module_name:sub(-4) ~= ".lua" then
         return
       end
       local module = table_from_file("mods/" .. MODNAME .. "/modules/" .. module_name:sub(1, -5))
@@ -627,6 +626,7 @@ do -- VERSION 2.9
     end
 
     function add_listener(event, listener)
+      init_listeners()
       if not LISTENER.listeners[event] then
         LISTENER.listeners[event] = {}
       end


### PR DESCRIPTION
uuuhhhhh this might also be true for remove_listener or a few other functions but right now this worked for me